### PR TITLE
Added remainingSeconds prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ npm install react-countdown360
 Render your countdown:
 
 ```js
-import Countdown360 from 'react-countdown360';
+import Countdown360 from 'react-countdown360'
 
 const App = () => {
-  return <Countdown360 seconds={10} />;
-};
+  return <Countdown360 seconds={10} />
+}
 ```
 
 ## Documentation
@@ -56,7 +56,7 @@ const App = () => {
 | `onComplete`        | Function | `undefined`            | A callback called when the countdown is over                   |
 | `smooth`            | Boolean  | `false`                | Update the border once every second or smoothly                |
 | `startingAngle`     | Number   | 0                      | The angle at which the countdown should start                  |
-| `startingSecond`    | Number   | undefined              | The second at which the countdown should start                 |
+| `startingSecond`    | Number   | `undefined`            | The second at which the countdown should start                 |
 | `timeFormatter`     | Func     | `timeFormatterSeconds` | A function that returns the value to display                   |
 | `unitFormatter`     | Func     | `unitFormatterSeconds` | A function that returns the unit to display                    |
 | `width`             | Number   | 200                    | Width in pixels of the countdown to render                     |
@@ -74,10 +74,8 @@ For instance, the following function is a time formatter that always shows a val
 
 ```js
 const timeFormatterTwoDigits = timeLeft => {
-  return Math.round(timeLeft / 1000)
-    .toString()
-    .padStart(2, "0");
-};
+  return Math.round(timeLeft / 1000).toString().padStart(2, "0")
+}
 ```
 
 We already provide a few time formatters that you can import from the package.
@@ -98,8 +96,8 @@ For instance, the following function is a unit formatter to show the number of s
 
 ```js
 const unitFormatterSpanishSeconds = value => {
-  return value.toString() === "1" ? "segundo" : "segundos";
-};
+  return value.toString() === "1" ? "segundo" : "segundos"
+}
 ```
 
 Be careful when choosing your unit formatter that it matches the time formatter in use!

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install react-countdown360
 Render your countdown:
 
 ```js
-import Countdown360 from "react-countdown360";
+import Countdown360 from 'react-countdown360';
 
 const App = () => {
   return <Countdown360 seconds={10} />;
@@ -43,7 +43,6 @@ const App = () => {
 | Name                | Type     | Default                | Description                                                    |
 | ------------------- | -------- | ---------------------- | -------------------------------------------------------------- |
 | `seconds`           | Number   | -                      | Number of seconds for the countdown                            |
-| `remainingSeconds`  | Number   | -                      | Number of remaining seconds from total seconds (seconds props) |
 | `autoStart`         | Boolean  | `true`                 | Start the countdown immediatly after rendering                 |
 | `backgroundColor`   | String   | `'#fff'`               | Color for the center of the circle                             |
 | `borderFillColor`   | String   | `'#f11'`               | Color for the filled part of the border                        |
@@ -57,6 +56,7 @@ const App = () => {
 | `onComplete`        | Function | `undefined`            | A callback called when the countdown is over                   |
 | `smooth`            | Boolean  | `false`                | Update the border once every second or smoothly                |
 | `startingAngle`     | Number   | 0                      | The angle at which the countdown should start                  |
+| `startingSecond`    | Number   | undefined              | The second at which the countdown should start                 |
 | `timeFormatter`     | Func     | `timeFormatterSeconds` | A function that returns the value to display                   |
 | `unitFormatter`     | Func     | `unitFormatterSeconds` | A function that returns the unit to display                    |
 | `width`             | Number   | 200                    | Width in pixels of the countdown to render                     |

--- a/README.md
+++ b/README.md
@@ -14,11 +14,9 @@ You can find some examples in the [`examples` directory](https://github.com/juli
 ![Stylized example][example2]
 ![Formatter example][example3]
 
-
 [example1]: https://raw.githubusercontent.com/julienc91/react-countdown360/master/doc/01_basic_countdown.gif "Baic example"
 [example2]: https://raw.githubusercontent.com/julienc91/react-countdown360/master/doc/02_stylized_countdown.gif "Stylized example"
 [example3]: https://raw.githubusercontent.com/julienc91/react-countdown360/master/doc/05_custom_formatters_countdown.gif "Formatter example"
-
 
 ## Quickstart
 
@@ -31,37 +29,37 @@ npm install react-countdown360
 Render your countdown:
 
 ```js
-import Countdown360 from 'react-countdown360'
+import Countdown360 from "react-countdown360";
 
 const App = () => {
-  return <Countdown360 seconds={10} />
-}
+  return <Countdown360 seconds={10} />;
+};
 ```
 
 ## Documentation
 
 ### Props
 
-| Name                | Type     | Default                 | Description                                     |
-|---------------------|----------|-------------------------|-------------------------------------------------|
-| `seconds`           | Number   | -                       | Number of seconds for the countdown             |
-| `autoStart`         | Boolean  | `true`                  | Start the countdown immediatly after rendering  |
-| `backgroundColor`   | String   | `'#fff'`                | Color for the center of the circle              |
-| `borderFillColor`   | String   | `'#f11'`                | Color for the filled part of the border         |
-| `borderUnfillColor` | String   | `'#e6e2e7'`             | Color for the unfilled part of the border       |
-| `borderWidth`       | Number   | 20                      | Width in pixels of the border                   |
-| `clockwise`         | Boolean  | `false`                 | Select the direction of rotation you prefer     |
-| `fontColor`         | String   | `'#111'`                | Font color for the label                        |
-| `fontFamily`        | String   | `'sans-serif'`          | The font to use for the label                   |
-| `fontSize`          | Number   | 45                      | Font size in pixels                             |
-| `fontWeight`        | Number   | 700                     | Font weight for the label                       |
-| `onComplete`        | Function | `undefined`             | A callback called when the countdown is over    |
-| `smooth`            | Boolean  | `false`                 | Update the border once every second or smoothly |
-| `startingAngle`     | Number   | 0                       | The angle at which the countdown should start   |
-| `timeFormatter`     | Func     | `timeFormatterSeconds`  | A function that returns the value to display    |
-| `unitFormatter`     | Func     | `unitFormatterSeconds`  | A function that returns the unit to display     |
-| `width`             | Number   | 200                     | Width in pixels of the countdown to render      |
-
+| Name                | Type     | Default                | Description                                                    |
+| ------------------- | -------- | ---------------------- | -------------------------------------------------------------- |
+| `seconds`           | Number   | -                      | Number of seconds for the countdown                            |
+| `remainingSeconds`  | Number   | -                      | Number of remaining seconds from total seconds (seconds props) |
+| `autoStart`         | Boolean  | `true`                 | Start the countdown immediatly after rendering                 |
+| `backgroundColor`   | String   | `'#fff'`               | Color for the center of the circle                             |
+| `borderFillColor`   | String   | `'#f11'`               | Color for the filled part of the border                        |
+| `borderUnfillColor` | String   | `'#e6e2e7'`            | Color for the unfilled part of the border                      |
+| `borderWidth`       | Number   | 20                     | Width in pixels of the border                                  |
+| `clockwise`         | Boolean  | `false`                | Select the direction of rotation you prefer                    |
+| `fontColor`         | String   | `'#111'`               | Font color for the label                                       |
+| `fontFamily`        | String   | `'sans-serif'`         | The font to use for the label                                  |
+| `fontSize`          | Number   | 45                     | Font size in pixels                                            |
+| `fontWeight`        | Number   | 700                    | Font weight for the label                                      |
+| `onComplete`        | Function | `undefined`            | A callback called when the countdown is over                   |
+| `smooth`            | Boolean  | `false`                | Update the border once every second or smoothly                |
+| `startingAngle`     | Number   | 0                      | The angle at which the countdown should start                  |
+| `timeFormatter`     | Func     | `timeFormatterSeconds` | A function that returns the value to display                   |
+| `unitFormatter`     | Func     | `unitFormatterSeconds` | A function that returns the unit to display                    |
+| `width`             | Number   | 200                    | Width in pixels of the countdown to render                     |
 
 #### Time Formatters
 
@@ -76,31 +74,32 @@ For instance, the following function is a time formatter that always shows a val
 
 ```js
 const timeFormatterTwoDigits = timeLeft => {
-  return Math.round(timeLeft / 1000).toString().padStart(2, '0')
-}
-``` 
+  return Math.round(timeLeft / 1000)
+    .toString()
+    .padStart(2, "0");
+};
+```
 
 We already provide a few time formatters that you can import from the package.
 
 | Name                        | Description                                   | Examples                   | Suggested unit formatter |
-|-----------------------------|-----------------------------------------------|----------------------------|--------------------------|
+| --------------------------- | --------------------------------------------- | -------------------------- | ------------------------ |
 | `timeFormatterSeconds`      | Rounded number of seconds (default behaviour) | `0`, `1`, `12`             | `unitFormatterSeconds`   |
 | `timeFormatterDigitalClock` | `MM:SS`                                       | `00:00`, `00:12`, `01: 59` | `unitFormatterBlank`     |
-
 
 #### Unit Formatters
 
 You can also customize the unit shown on the countdown by providing a custom `unitFormatter` function.
 
-A unit formatter is a function that takes one single argument, being the value shown on the countdown (as 
+A unit formatter is a function that takes one single argument, being the value shown on the countdown (as
 returned by the given time formatter), and returns the unit to display.
 
 For instance, the following function is a unit formatter to show the number of seconds in Spanish:
 
 ```js
 const unitFormatterSpanishSeconds = value => {
-  return value.toString() === '1' ? 'segundo' : 'segundos'
-}
+  return value.toString() === "1" ? "segundo" : "segundos";
+};
 ```
 
 Be careful when choosing your unit formatter that it matches the time formatter in use!
@@ -108,15 +107,13 @@ Be careful when choosing your unit formatter that it matches the time formatter 
 We already provide a few unit formatters that you can import from the package.
 
 | Name                   | Description           | Examples            |
-|------------------------|-----------------------|---------------------|
+| ---------------------- | --------------------- | ------------------- |
 | `unitFormatterSeconds` | 'second' or 'seconds' | `second`, `seconds` |
 | `unitFormatterBlank`   | An empty string       |                     |
 
-
-
 ### Methods
 
-* `start`: start or resume the countdown
-* `stop`: pause the countdown
-* `addSeconds (Number)`: add or remove (if negative) the given number of seconds to remaining number of seconds
-* `extendTimer (Number)`: add or remove (if negative) the given number of seconds to the total number of seconds
+- `start`: start or resume the countdown
+- `stop`: pause the countdown
+- `addSeconds (Number)`: add or remove (if negative) the given number of seconds to remaining number of seconds
+- `extendTimer (Number)`: add or remove (if negative) the given number of seconds to the total number of seconds

--- a/src/countdown360.js
+++ b/src/countdown360.js
@@ -1,122 +1,122 @@
-import React from "react";
-import PropTypes from "prop-types";
-import styled from "styled-components";
-import { timeFormatterSeconds } from "./timeFormatters";
-import { unitFormatterSeconds } from "./unitFormatters";
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { timeFormatterSeconds } from './timeFormatters'
+import { unitFormatterSeconds } from './unitFormatters'
 
 class Countdown360 extends React.Component {
-  constructor(props) {
-    super(props);
-    const seconds = Math.max(props.seconds, 0);
+  constructor (props) {
+    super(props)
+    const seconds = Math.max(props.seconds, 0)
     const secondsLeft =
       props.remainingSeconds && props.remainingSeconds > 0
         ? Math.min(seconds, props.remainingSeconds)
-        : seconds;
+        : seconds
 
     this.state = {
       totalSeconds: seconds,
       secondsLeft: secondsLeft * 1000,
       started: false,
       lastTick: null
-    };
+    }
 
-    this.interval = null;
-    this.handleTick = this.handleTick.bind(this);
+    this.interval = null
+    this.handleTick = this.handleTick.bind(this)
   }
 
-  componentDidMount() {
-    const { autoStart } = this.props;
+  componentDidMount () {
+    const { autoStart } = this.props
     if (autoStart) {
-      this.start();
+      this.start()
     }
   }
 
-  componentWillUnmount() {
-    clearInterval(this.interval);
-    this.interval = null;
+  componentWillUnmount () {
+    clearInterval(this.interval)
+    this.interval = null
   }
 
-  componentDidUpdate(prevProps) {
-    const { smooth } = this.props;
+  componentDidUpdate (prevProps) {
+    const { smooth } = this.props
     if (prevProps.smooth !== smooth) {
-      clearInterval(this.interval);
-      this.interval = setInterval(this.handleTick, smooth ? 16 : 1000);
+      clearInterval(this.interval)
+      this.interval = setInterval(this.handleTick, smooth ? 16 : 1000)
     }
   }
 
-  extendTimer(value) {
-    let { secondsLeft, totalSeconds } = this.state;
-    totalSeconds += value;
-    totalSeconds = Math.max(totalSeconds, 0);
+  extendTimer (value) {
+    let { secondsLeft, totalSeconds } = this.state
+    totalSeconds += value
+    totalSeconds = Math.max(totalSeconds, 0)
 
-    secondsLeft = Math.min(secondsLeft, totalSeconds * 1000);
-    this.setState({ secondsLeft, totalSeconds });
+    secondsLeft = Math.min(secondsLeft, totalSeconds * 1000)
+    this.setState({ secondsLeft, totalSeconds })
   }
 
-  addSeconds(value) {
-    const { secondsLeft, totalSeconds } = this.state;
-    value *= 1000;
+  addSeconds (value) {
+    const { secondsLeft, totalSeconds } = this.state
+    value *= 1000
     this.setState({
       secondsLeft: Math.max(
         Math.min(secondsLeft + value, totalSeconds * 1000),
         0
       )
-    });
+    })
   }
 
-  start() {
-    const { secondsLeft, started } = this.state;
+  start () {
+    const { secondsLeft, started } = this.state
     if (started || secondsLeft <= 0) {
-      return;
+      return
     }
 
-    const { smooth } = this.props;
-    const timerInterval = smooth ? 16 : 1000;
-    this.handleTick();
-    this.interval = setInterval(this.handleTick, timerInterval);
-    this.setState({ started: true });
+    const { smooth } = this.props
+    const timerInterval = smooth ? 16 : 1000
+    this.handleTick()
+    this.interval = setInterval(this.handleTick, timerInterval)
+    this.setState({ started: true })
   }
 
-  stop() {
-    const { started } = this.state;
+  stop () {
+    const { started } = this.state
     if (!started) {
-      return;
+      return
     }
-    clearInterval(this.interval);
-    this.interval = null;
+    clearInterval(this.interval)
+    this.interval = null
 
-    this.handleTick();
-    this.setState({ started: false, lastTick: null });
+    this.handleTick()
+    this.setState({ started: false, lastTick: null })
   }
 
-  handleTick() {
-    const { secondsLeft, started } = this.state;
+  handleTick () {
+    const { secondsLeft, started } = this.state
     if (!started || secondsLeft <= 0) {
-      return;
+      return
     }
 
-    const now = new Date();
-    const lastTick = this.state.lastTick || now;
+    const now = new Date()
+    const lastTick = this.state.lastTick || now
 
-    const diff = Math.abs(now - lastTick);
-    const updatedSecondsLeft = Math.max(secondsLeft - diff, 0);
+    const diff = Math.abs(now - lastTick)
+    const updatedSecondsLeft = Math.max(secondsLeft - diff, 0)
     this.setState({ lastTick: now, secondsLeft: updatedSecondsLeft }, () => {
       if (updatedSecondsLeft <= 0) {
-        const { onComplete } = this.props;
-        onComplete && onComplete();
-        this.stop();
+        const { onComplete } = this.props
+        onComplete && onComplete()
+        this.stop()
       }
-    });
+    })
   }
 
-  render() {
-    const { clockwise, smooth, startingAngle, width } = this.props;
+  render () {
+    const { clockwise, smooth, startingAngle, width } = this.props
     const {
       backgroundColor,
       borderUnfillColor,
       borderFillColor,
       borderWidth
-    } = this.props;
+    } = this.props
     const {
       fontColor,
       fontFamily,
@@ -124,20 +124,20 @@ class Countdown360 extends React.Component {
       fontWeight,
       timeFormatter,
       unitFormatter
-    } = this.props;
+    } = this.props
 
-    const { secondsLeft, totalSeconds } = this.state;
+    const { secondsLeft, totalSeconds } = this.state
 
-    let angle;
+    let angle
     if (!smooth) {
-      angle = (Math.round(secondsLeft / 1000) / totalSeconds) * 360;
+      angle = (Math.round(secondsLeft / 1000) / totalSeconds) * 360
     } else {
-      angle = (secondsLeft / (totalSeconds * 1000)) * 360;
+      angle = (secondsLeft / (totalSeconds * 1000)) * 360
     }
 
-    const factor = clockwise ? -1 : 1;
-    const x = (angle >= 180 ? 90 - (360 - angle) : 90) * factor + startingAngle;
-    const y = (angle >= 180 ? 90 : -90 + angle) * factor + startingAngle;
+    const factor = clockwise ? -1 : 1
+    const x = (angle >= 180 ? 90 - (360 - angle) : 90) * factor + startingAngle
+    const y = (angle >= 180 ? 90 : -90 + angle) * factor + startingAngle
 
     const Wrapper = styled.div`
       align-items: center;
@@ -156,7 +156,7 @@ class Countdown360 extends React.Component {
       height: ${width}px;
       justify-content: center;
       width: ${width}px;
-    `;
+    `
 
     const Label = styled.div`
       align-items: center;
@@ -174,15 +174,15 @@ class Countdown360 extends React.Component {
       text-align: center;
       text-transform: uppercase;
       width: ${width - 2 * borderWidth}px;
-    `;
+    `
 
     const Unit = styled.div`
       text-transform: uppercase;
       font-size: ${fontSize / 3}px;
-    `;
+    `
 
-    const value = timeFormatter(secondsLeft);
-    const unit = unitFormatter(value);
+    const value = timeFormatter(secondsLeft)
+    const unit = unitFormatter(value)
 
     return (
       <Wrapper>
@@ -192,19 +192,19 @@ class Countdown360 extends React.Component {
           <Unit>{unit}</Unit>
         </Label>
       </Wrapper>
-    );
+    )
   }
 }
 
 Countdown360.defaultProps = {
   autoStart: true,
-  backgroundColor: "#fff",
-  borderFillColor: "#f11",
-  borderUnfillColor: "#e6e2e7",
+  backgroundColor: '#fff',
+  borderFillColor: '#f11',
+  borderUnfillColor: '#e6e2e7',
   borderWidth: 20,
   clockwise: false,
-  fontColor: "#111",
-  fontFamily: "sans-serif",
+  fontColor: '#111',
+  fontFamily: 'sans-serif',
   fontSize: 45,
   fontWeight: 700,
   smooth: false,
@@ -212,7 +212,7 @@ Countdown360.defaultProps = {
   timeFormatter: timeFormatterSeconds,
   unitFormatter: unitFormatterSeconds,
   width: 200
-};
+}
 
 Countdown360.propTypes = {
   autoStart: PropTypes.bool,
@@ -233,6 +233,6 @@ Countdown360.propTypes = {
   unitFormatter: PropTypes.func,
   width: PropTypes.number,
   remainingSeconds: PropTypes.number
-};
+}
 
-export default Countdown360;
+export default Countdown360

--- a/src/countdown360.js
+++ b/src/countdown360.js
@@ -1,130 +1,162 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import styled from 'styled-components'
-import { timeFormatterSeconds } from './timeFormatters'
-import { unitFormatterSeconds } from './unitFormatters'
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { timeFormatterSeconds } from "./timeFormatters";
+import { unitFormatterSeconds } from "./unitFormatters";
 
 class Countdown360 extends React.Component {
-  constructor (props) {
-    super(props)
-    const seconds = Math.max(props.seconds, 0)
+  constructor(props) {
+    super(props);
+    const seconds = Math.max(props.seconds, 0);
+    const secondsLeft =
+      props.remainingSeconds && props.remainingSeconds > 0
+        ? Math.min(seconds, props.remainingSeconds)
+        : seconds;
+
     this.state = {
       totalSeconds: seconds,
-      secondsLeft: seconds * 1000,
+      secondsLeft: secondsLeft * 1000,
       started: false,
       lastTick: null
-    }
+    };
 
-    this.interval = null
-    this.handleTick = this.handleTick.bind(this)
+    this.interval = null;
+    this.handleTick = this.handleTick.bind(this);
   }
 
-  componentDidMount () {
-    const { autoStart } = this.props
+  componentDidMount() {
+    const { autoStart } = this.props;
     if (autoStart) {
-      this.start()
+      this.start();
     }
   }
 
-  componentWillUnmount () {
-    clearInterval(this.interval)
-    this.interval = null
+  componentWillUnmount() {
+    clearInterval(this.interval);
+    this.interval = null;
   }
 
-  componentDidUpdate (prevProps) {
-    const { smooth } = this.props
+  componentDidUpdate(prevProps) {
+    const { smooth } = this.props;
     if (prevProps.smooth !== smooth) {
-      clearInterval(this.interval)
-      this.interval = setInterval(this.handleTick, smooth ? 16 : 1000)
+      clearInterval(this.interval);
+      this.interval = setInterval(this.handleTick, smooth ? 16 : 1000);
     }
   }
 
-  extendTimer (value) {
-    let { secondsLeft, totalSeconds } = this.state
-    totalSeconds += value
-    totalSeconds = Math.max(totalSeconds, 0)
+  extendTimer(value) {
+    let { secondsLeft, totalSeconds } = this.state;
+    totalSeconds += value;
+    totalSeconds = Math.max(totalSeconds, 0);
 
-    secondsLeft = Math.min(secondsLeft, totalSeconds * 1000)
-    this.setState({ secondsLeft, totalSeconds })
+    secondsLeft = Math.min(secondsLeft, totalSeconds * 1000);
+    this.setState({ secondsLeft, totalSeconds });
   }
 
-  addSeconds (value) {
-    const { secondsLeft, totalSeconds } = this.state
-    value *= 1000
-    this.setState({ secondsLeft: Math.max(Math.min(secondsLeft + value, totalSeconds * 1000), 0) })
+  addSeconds(value) {
+    const { secondsLeft, totalSeconds } = this.state;
+    value *= 1000;
+    this.setState({
+      secondsLeft: Math.max(
+        Math.min(secondsLeft + value, totalSeconds * 1000),
+        0
+      )
+    });
   }
 
-  start () {
-    const { secondsLeft, started } = this.state
+  start() {
+    const { secondsLeft, started } = this.state;
     if (started || secondsLeft <= 0) {
-      return
+      return;
     }
 
-    const { smooth } = this.props
-    const timerInterval = smooth ? 16 : 1000
-    this.handleTick()
-    this.interval = setInterval(this.handleTick, timerInterval)
-    this.setState({ started: true })
+    const { smooth } = this.props;
+    const timerInterval = smooth ? 16 : 1000;
+    this.handleTick();
+    this.interval = setInterval(this.handleTick, timerInterval);
+    this.setState({ started: true });
   }
 
-  stop () {
-    const { started } = this.state
+  stop() {
+    const { started } = this.state;
     if (!started) {
-      return
+      return;
     }
-    clearInterval(this.interval)
-    this.interval = null
+    clearInterval(this.interval);
+    this.interval = null;
 
-    this.handleTick()
-    this.setState({ started: false, lastTick: null })
+    this.handleTick();
+    this.setState({ started: false, lastTick: null });
   }
 
-  handleTick () {
-    const { secondsLeft, started } = this.state
+  handleTick() {
+    const { secondsLeft, started } = this.state;
     if (!started || secondsLeft <= 0) {
-      return
+      return;
     }
 
-    const now = new Date()
-    const lastTick = this.state.lastTick || now
+    const now = new Date();
+    const lastTick = this.state.lastTick || now;
 
-    const diff = Math.abs(now - lastTick)
-    const updatedSecondsLeft = Math.max(secondsLeft - diff, 0)
+    const diff = Math.abs(now - lastTick);
+    const updatedSecondsLeft = Math.max(secondsLeft - diff, 0);
     this.setState({ lastTick: now, secondsLeft: updatedSecondsLeft }, () => {
       if (updatedSecondsLeft <= 0) {
-        const { onComplete } = this.props
-        onComplete && onComplete()
-        this.stop()
+        const { onComplete } = this.props;
+        onComplete && onComplete();
+        this.stop();
       }
-    })
+    });
   }
 
-  render () {
-    const { clockwise, smooth, startingAngle, width } = this.props
-    const { backgroundColor, borderUnfillColor, borderFillColor, borderWidth } = this.props
-    const { fontColor, fontFamily, fontSize, fontWeight, timeFormatter, unitFormatter } = this.props
+  render() {
+    const { clockwise, smooth, startingAngle, width } = this.props;
+    const {
+      backgroundColor,
+      borderUnfillColor,
+      borderFillColor,
+      borderWidth
+    } = this.props;
+    const {
+      fontColor,
+      fontFamily,
+      fontSize,
+      fontWeight,
+      timeFormatter,
+      unitFormatter
+    } = this.props;
 
-    const { secondsLeft, totalSeconds } = this.state
+    const { secondsLeft, totalSeconds } = this.state;
 
-    let angle
+    let angle;
     if (!smooth) {
-      angle = (Math.round(secondsLeft / 1000) / totalSeconds) * 360
+      angle = (Math.round(secondsLeft / 1000) / totalSeconds) * 360;
     } else {
-      angle = (secondsLeft / (totalSeconds * 1000)) * 360
+      angle = (secondsLeft / (totalSeconds * 1000)) * 360;
     }
 
-    const factor = clockwise ? -1 : 1
-    const x = ((angle >= 180 ? (90 - (360 - angle)) : 90) * factor) + startingAngle
-    const y = ((angle >= 180 ? 90 : (-90 + angle)) * factor) + startingAngle
+    const factor = clockwise ? -1 : 1;
+    const x = (angle >= 180 ? 90 - (360 - angle) : 90) * factor + startingAngle;
+    const y = (angle >= 180 ? 90 : -90 + angle) * factor + startingAngle;
 
     const Wrapper = styled.div`
       align-items: center;
-      background-image: linear-gradient(${x}deg, ${angle >= 180 ? borderFillColor : borderUnfillColor} 50%, transparent 50%), linear-gradient(${y}deg, ${borderUnfillColor} 50%, ${borderFillColor} 50%);
+      background-image: linear-gradient(
+          ${x}deg,
+          ${angle >= 180 ? borderFillColor : borderUnfillColor} 50%,
+          transparent 50%
+        ),
+        linear-gradient(
+          ${y}deg,
+          ${borderUnfillColor} 50%,
+          ${borderFillColor} 50%
+        );
       border-radius: 50%;
       display: flex;
       height: ${width}px;
       justify-content: center;
-      width: ${width}px;`
+      width: ${width}px;
+    `;
 
     const Label = styled.div`
       align-items: center;
@@ -141,35 +173,38 @@ class Countdown360 extends React.Component {
       justify-content: center;
       text-align: center;
       text-transform: uppercase;
-      width: ${width - 2 * borderWidth}px;`
+      width: ${width - 2 * borderWidth}px;
+    `;
 
     const Unit = styled.div`
       text-transform: uppercase;
-      font-size: ${fontSize / 3}px;`
+      font-size: ${fontSize / 3}px;
+    `;
 
-    const value = timeFormatter(secondsLeft)
-    const unit = unitFormatter(value)
+    const value = timeFormatter(secondsLeft);
+    const unit = unitFormatter(value);
 
     return (
       <Wrapper>
         <Label>
-          {value}<br />
+          {value}
+          <br />
           <Unit>{unit}</Unit>
         </Label>
       </Wrapper>
-    )
+    );
   }
 }
 
 Countdown360.defaultProps = {
   autoStart: true,
-  backgroundColor: '#fff',
-  borderFillColor: '#f11',
-  borderUnfillColor: '#e6e2e7',
+  backgroundColor: "#fff",
+  borderFillColor: "#f11",
+  borderUnfillColor: "#e6e2e7",
   borderWidth: 20,
   clockwise: false,
-  fontColor: '#111',
-  fontFamily: 'sans-serif',
+  fontColor: "#111",
+  fontFamily: "sans-serif",
   fontSize: 45,
   fontWeight: 700,
   smooth: false,
@@ -177,7 +212,7 @@ Countdown360.defaultProps = {
   timeFormatter: timeFormatterSeconds,
   unitFormatter: unitFormatterSeconds,
   width: 200
-}
+};
 
 Countdown360.propTypes = {
   autoStart: PropTypes.bool,
@@ -196,7 +231,8 @@ Countdown360.propTypes = {
   startingAngle: PropTypes.number,
   timeFormatter: PropTypes.func,
   unitFormatter: PropTypes.func,
-  width: PropTypes.number
-}
+  width: PropTypes.number,
+  remainingSeconds: PropTypes.number
+};
 
-export default Countdown360
+export default Countdown360;

--- a/src/countdown360.js
+++ b/src/countdown360.js
@@ -9,8 +9,8 @@ class Countdown360 extends React.Component {
     super(props)
     const seconds = Math.max(props.seconds, 0)
     const secondsLeft =
-      props.remainingSeconds && props.remainingSeconds > 0
-        ? Math.min(seconds, props.remainingSeconds)
+      props.startingSecond && props.startingSecond > 0
+        ? Math.min(seconds, props.startingSecond)
         : seconds
 
     this.state = {
@@ -229,10 +229,10 @@ Countdown360.propTypes = {
   seconds: PropTypes.number.isRequired,
   smooth: PropTypes.bool,
   startingAngle: PropTypes.number,
+  startingSecond: PropTypes.number,
   timeFormatter: PropTypes.func,
   unitFormatter: PropTypes.func,
-  width: PropTypes.number,
-  remainingSeconds: PropTypes.number
+  width: PropTypes.number
 }
 
 export default Countdown360

--- a/tests/countdown360.test.js
+++ b/tests/countdown360.test.js
@@ -1,243 +1,243 @@
-import React from "react";
-import renderer from "react-test-renderer";
-import Countdown360 from "../src";
+import React from 'react'
+import renderer from 'react-test-renderer'
+import Countdown360 from '../src'
 
-test("Initialization of totalSeconds", () => {
+test('Initialization of totalSeconds', () => {
   [0, 1, 10, 42].forEach(seconds => {
-    const component = renderer.create(<Countdown360 seconds={seconds} />);
-    const instance = component.getInstance();
-    expect(instance.state.totalSeconds).toBe(seconds);
-    expect(instance.state.secondsLeft).toBe(seconds * 1000);
-  });
-});
+    const component = renderer.create(<Countdown360 seconds={seconds} />)
+    const instance = component.getInstance()
+    expect(instance.state.totalSeconds).toBe(seconds)
+    expect(instance.state.secondsLeft).toBe(seconds * 1000)
+  })
+})
 
-test("Initialization of totalSeconds with negative value", () => {
-  const seconds = -42;
-  const component = renderer.create(<Countdown360 seconds={seconds} />);
-  const instance = component.getInstance();
-  expect(instance.state.totalSeconds).toBe(0);
-  expect(instance.state.secondsLeft).toBe(0);
-});
+test('Initialization of totalSeconds with negative value', () => {
+  const seconds = -42
+  const component = renderer.create(<Countdown360 seconds={seconds} />)
+  const instance = component.getInstance()
+  expect(instance.state.totalSeconds).toBe(0)
+  expect(instance.state.secondsLeft).toBe(0)
+})
 
-test("Smooth initialization", () => {
-  const seconds = 42;
-  const component = renderer.create(<Countdown360 seconds={seconds} smooth />);
-  const instance = component.getInstance();
-  expect(instance.interval).not.toBeNull();
-});
+test('Smooth initialization', () => {
+  const seconds = 42
+  const component = renderer.create(<Countdown360 seconds={seconds} smooth />)
+  const instance = component.getInstance()
+  expect(instance.interval).not.toBeNull()
+})
 
-test("Clockwise rotation", () => {
-  const component = renderer.create(<Countdown360 seconds={42} clockwise />);
-  const instance = component.getInstance();
-  expect(instance.interval).not.toBeNull();
-});
+test('Clockwise rotation', () => {
+  const component = renderer.create(<Countdown360 seconds={42} clockwise />)
+  const instance = component.getInstance()
+  expect(instance.interval).not.toBeNull()
+})
 
-test("Initialization with autoStart", () => {
+test('Initialization with autoStart', () => {
   [true, false].forEach(autoStart => {
     const component = renderer.create(
       <Countdown360 seconds={42} autoStart={autoStart} />
-    );
-    const instance = component.getInstance();
-    expect(instance.state.started).toBe(autoStart);
-  });
-});
+    )
+    const instance = component.getInstance()
+    expect(instance.state.started).toBe(autoStart)
+  })
+})
 
-test("Start and stop", () => {
+test('Start and stop', () => {
   const component = renderer.create(
     <Countdown360 seconds={42} autoStart={false} />
-  );
-  const instance = component.getInstance();
-  expect(instance.state.started).toBe(false);
+  )
+  const instance = component.getInstance()
+  expect(instance.state.started).toBe(false)
 
-  instance.start();
-  expect(instance.state.started).toBe(true);
+  instance.start()
+  expect(instance.state.started).toBe(true)
 
-  instance.stop();
-  expect(instance.state.started).toBe(false);
-});
+  instance.stop()
+  expect(instance.state.started).toBe(false)
+})
 
-test("Start and stop while already started or stopped", () => {
+test('Start and stop while already started or stopped', () => {
   const component = renderer.create(
-    <Countdown360 seconds={42} autoStart={true} />
-  );
-  const instance = component.getInstance();
-  expect(instance.state.started).toBe(true);
+    <Countdown360 seconds={42} autoStart />
+  )
+  const instance = component.getInstance()
+  expect(instance.state.started).toBe(true)
 
-  instance.start();
-  expect(instance.state.started).toBe(true);
+  instance.start()
+  expect(instance.state.started).toBe(true)
 
   for (let i = 0; i < 2; i++) {
-    instance.stop();
-    expect(instance.state.started).toBe(false);
+    instance.stop()
+    expect(instance.state.started).toBe(false)
   }
-});
+})
 
-test("Setup or clear interval when starting and stopping", () => {
+test('Setup or clear interval when starting and stopping', () => {
   const component = renderer.create(
     <Countdown360 seconds={42} autoStart={false} />
-  );
-  const instance = component.getInstance();
-  expect(instance.interval).toBeNull();
+  )
+  const instance = component.getInstance()
+  expect(instance.interval).toBeNull()
 
-  instance.start();
-  expect(instance.interval).not.toBeNull();
+  instance.start()
+  expect(instance.interval).not.toBeNull()
 
-  instance.stop();
-  expect(instance.interval).toBeNull();
-});
+  instance.stop()
+  expect(instance.interval).toBeNull()
+})
 
-test("Update interval when changing smooth", () => {
+test('Update interval when changing smooth', () => {
   class ChangeSmoothnessWrapper extends React.Component {
-    constructor(props) {
-      super(props);
-      this.state = { smooth: props.smooth };
+    constructor (props) {
+      super(props)
+      this.state = { smooth: props.smooth }
     }
 
-    toggleSmoothness(smooth) {
-      this.setState({ smooth });
+    toggleSmoothness (smooth) {
+      this.setState({ smooth })
     }
 
-    render() {
+    render () {
       return (
         <Countdown360
           seconds={42}
           smooth={this.state.smooth}
           ref={c => {
-            this.c = c;
+            this.c = c
           }}
         />
-      );
+      )
     }
   }
 
-  const component = renderer.create(<ChangeSmoothnessWrapper smooth={false} />);
-  const wrapper = component.getInstance();
-  const instance = wrapper.c;
-  let interval = instance.interval;
-  expect(interval).not.toBeNull();
+  const component = renderer.create(<ChangeSmoothnessWrapper smooth={false} />)
+  const wrapper = component.getInstance()
+  const instance = wrapper.c
+  let interval = instance.interval
+  expect(interval).not.toBeNull()
 
-  wrapper.toggleSmoothness(true);
-  expect(instance.interval).not.toBeNull();
-  expect(instance.interval).not.toBe(interval);
-  interval = instance.interval;
+  wrapper.toggleSmoothness(true)
+  expect(instance.interval).not.toBeNull()
+  expect(instance.interval).not.toBe(interval)
+  interval = instance.interval
 
-  wrapper.toggleSmoothness(false);
-  expect(instance.interval).not.toBeNull();
-  expect(instance.interval).not.toBe(interval);
-});
+  wrapper.toggleSmoothness(false)
+  expect(instance.interval).not.toBeNull()
+  expect(instance.interval).not.toBe(interval)
+})
 
-test("Extend timer", () => {
+test('Extend timer', () => {
   [10, -10, -100].forEach(value => {
-    const seconds = 42;
-    const component = renderer.create(<Countdown360 seconds={seconds} />);
-    const instance = component.getInstance();
-    instance.extendTimer(value);
-    const expected = Math.max(seconds + value, 0);
-    expect(instance.state.totalSeconds).toBe(expected);
-    expect(instance.state.secondsLeft).toBeLessThanOrEqual(expected * 1000);
-  });
-});
+    const seconds = 42
+    const component = renderer.create(<Countdown360 seconds={seconds} />)
+    const instance = component.getInstance()
+    instance.extendTimer(value)
+    const expected = Math.max(seconds + value, 0)
+    expect(instance.state.totalSeconds).toBe(expected)
+    expect(instance.state.secondsLeft).toBeLessThanOrEqual(expected * 1000)
+  })
+})
 
-test("Add seconds", () => {
+test('Add seconds', () => {
   [100, 10, -10, -100].forEach(value => {
-    const seconds = 42;
-    const secondsLeft = 30000;
-    const component = renderer.create(<Countdown360 seconds={seconds} />);
-    const instance = component.getInstance();
-    instance.state.secondsLeft = secondsLeft;
+    const seconds = 42
+    const secondsLeft = 30000
+    const component = renderer.create(<Countdown360 seconds={seconds} />)
+    const instance = component.getInstance()
+    instance.state.secondsLeft = secondsLeft
 
-    instance.addSeconds(value);
+    instance.addSeconds(value)
     const expected = Math.max(
       Math.min(secondsLeft + value * 1000, seconds * 1000),
       0
-    );
+    )
 
-    expect(instance.state.secondsLeft).toBe(expected);
-  });
-});
+    expect(instance.state.secondsLeft).toBe(expected)
+  })
+})
 
-test("Handle tick and finish", () => {
-  const seconds = 42;
-  const callback = jest.fn();
+test('Handle tick and finish', () => {
+  const seconds = 42
+  const callback = jest.fn()
   const component = renderer.create(
     <Countdown360 seconds={seconds} onComplete={callback} />
-  );
+  )
 
-  const instance = component.getInstance();
-  const secondsToRemove = 10;
-  let lastTick = new Date(new Date() - secondsToRemove * 1000);
-  instance.setState({ lastTick });
+  const instance = component.getInstance()
+  const secondsToRemove = 10
+  let lastTick = new Date(new Date() - secondsToRemove * 1000)
+  instance.setState({ lastTick })
 
-  instance.handleTick();
-  expect(instance.state.secondsLeft).toBeLessThan(seconds * 1000);
-  expect(instance.state.secondsLeft).toBeGreaterThan(0);
-  expect(callback).not.toHaveBeenCalled();
+  instance.handleTick()
+  expect(instance.state.secondsLeft).toBeLessThan(seconds * 1000)
+  expect(instance.state.secondsLeft).toBeGreaterThan(0)
+  expect(callback).not.toHaveBeenCalled()
 
-  lastTick = new Date(new Date() - seconds * 1000);
-  instance.setState({ lastTick });
+  lastTick = new Date(new Date() - seconds * 1000)
+  instance.setState({ lastTick })
 
-  instance.handleTick();
-  expect(instance.state.secondsLeft).toBe(0);
-  expect(callback).toHaveBeenCalledTimes(1);
-});
+  instance.handleTick()
+  expect(instance.state.secondsLeft).toBe(0)
+  expect(callback).toHaveBeenCalledTimes(1)
+})
 
-test("Handle tick while stopped", () => {
-  const seconds = 42;
+test('Handle tick while stopped', () => {
+  const seconds = 42
   const component = renderer.create(
     <Countdown360 seconds={seconds} autoStart={false} />
-  );
-  const instance = component.getInstance();
+  )
+  const instance = component.getInstance()
 
-  instance.handleTick();
-  expect(instance.state.secondsLeft).toBe(seconds * 1000);
-  expect(instance.state.lastTick).toBeNull();
-});
+  instance.handleTick()
+  expect(instance.state.secondsLeft).toBe(seconds * 1000)
+  expect(instance.state.lastTick).toBeNull()
+})
 
-test("Clear interval when unmounting", () => {
-  const component = renderer.create(<Countdown360 seconds={42} />);
-  const instance = component.getInstance();
-  expect(instance.interval).not.toBeNull();
-  component.unmount();
-  expect(instance.interval).toBeNull();
-});
+test('Clear interval when unmounting', () => {
+  const component = renderer.create(<Countdown360 seconds={42} />)
+  const instance = component.getInstance()
+  expect(instance.interval).not.toBeNull()
+  component.unmount()
+  expect(instance.interval).toBeNull()
+})
 
-test("Initialization of negative remaining seconds", () => {
-  const seconds = 30;
-  const remainingSeconds = -30;
+test('Initialization of negative remaining seconds', () => {
+  const seconds = 30
+  const remainingSeconds = -30
   const component = renderer.create(
     <Countdown360 seconds={seconds} remainingSeconds={remainingSeconds} />
-  );
-  const instance = component.getInstance();
-  expect(instance.state.totalSeconds).toBe(seconds);
-  expect(instance.state.secondsLeft).toBe(seconds * 1000);
-});
+  )
+  const instance = component.getInstance()
+  expect(instance.state.totalSeconds).toBe(seconds)
+  expect(instance.state.secondsLeft).toBe(seconds * 1000)
+})
 
-test("No Initialization of remaining seconds", () => {
-  const seconds = 30;
-  const component = renderer.create(<Countdown360 seconds={seconds} />);
-  const instance = component.getInstance();
-  expect(instance.state.totalSeconds).toBe(seconds);
-  expect(instance.state.secondsLeft).toBe(seconds * 1000);
-});
+test('No Initialization of remaining seconds', () => {
+  const seconds = 30
+  const component = renderer.create(<Countdown360 seconds={seconds} />)
+  const instance = component.getInstance()
+  expect(instance.state.totalSeconds).toBe(seconds)
+  expect(instance.state.secondsLeft).toBe(seconds * 1000)
+})
 
-test("Initialization of remaining seconds bigger than seconds", () => {
-  const seconds = 30;
-  const remainingSeconds = 40;
+test('Initialization of remaining seconds bigger than seconds', () => {
+  const seconds = 30
+  const remainingSeconds = 40
   const component = renderer.create(
     <Countdown360 seconds={seconds} remainingSeconds={remainingSeconds} />
-  );
-  const instance = component.getInstance();
-  expect(instance.state.totalSeconds).toBe(seconds);
-  expect(instance.state.secondsLeft).toBe(seconds * 1000);
-});
+  )
+  const instance = component.getInstance()
+  expect(instance.state.totalSeconds).toBe(seconds)
+  expect(instance.state.secondsLeft).toBe(seconds * 1000)
+})
 
-test("Initialization of remaining seconds", () => {
-  const seconds = 30;
-  const remainingSeconds = 20;
+test('Initialization of remaining seconds', () => {
+  const seconds = 30
+  const remainingSeconds = 20
   const component = renderer.create(
     <Countdown360 seconds={seconds} remainingSeconds={remainingSeconds} />
-  );
-  const instance = component.getInstance();
-  expect(instance.state.totalSeconds).toBe(seconds);
-  expect(instance.state.secondsLeft).toBe(remainingSeconds * 1000);
-});
+  )
+  const instance = component.getInstance()
+  expect(instance.state.totalSeconds).toBe(seconds)
+  expect(instance.state.secondsLeft).toBe(remainingSeconds * 1000)
+})

--- a/tests/countdown360.test.js
+++ b/tests/countdown360.test.js
@@ -1,207 +1,243 @@
-import React from 'react'
-import renderer from 'react-test-renderer'
-import Countdown360 from '../src'
+import React from "react";
+import renderer from "react-test-renderer";
+import Countdown360 from "../src";
 
-test('Initialization of totalSeconds', () => {
+test("Initialization of totalSeconds", () => {
   [0, 1, 10, 42].forEach(seconds => {
-    const component = renderer.create(
-      <Countdown360 seconds={seconds}/>
-    )
-    const instance = component.getInstance()
-    expect(instance.state.totalSeconds).toBe(seconds)
-    expect(instance.state.secondsLeft).toBe(seconds * 1000)
-  })
-})
+    const component = renderer.create(<Countdown360 seconds={seconds} />);
+    const instance = component.getInstance();
+    expect(instance.state.totalSeconds).toBe(seconds);
+    expect(instance.state.secondsLeft).toBe(seconds * 1000);
+  });
+});
 
-test('Initialization of totalSeconds with negative value', () => {
-  const seconds = -42
-  const component = renderer.create(
-    <Countdown360 seconds={seconds}/>
-  )
-  const instance = component.getInstance()
-  expect(instance.state.totalSeconds).toBe(0)
-  expect(instance.state.secondsLeft).toBe(0)
-})
+test("Initialization of totalSeconds with negative value", () => {
+  const seconds = -42;
+  const component = renderer.create(<Countdown360 seconds={seconds} />);
+  const instance = component.getInstance();
+  expect(instance.state.totalSeconds).toBe(0);
+  expect(instance.state.secondsLeft).toBe(0);
+});
 
-test('Smooth initialization', () => {
-  const seconds = 42
-  const component = renderer.create(
-    <Countdown360 seconds={seconds} smooth/>
-  )
-  const instance = component.getInstance()
-  expect(instance.interval).not.toBeNull()
-})
+test("Smooth initialization", () => {
+  const seconds = 42;
+  const component = renderer.create(<Countdown360 seconds={seconds} smooth />);
+  const instance = component.getInstance();
+  expect(instance.interval).not.toBeNull();
+});
 
-test('Clockwise rotation', () => {
-  const component = renderer.create(
-    <Countdown360 seconds={42} clockwise/>
-  )
-  const instance = component.getInstance()
-  expect(instance.interval).not.toBeNull()
-})
+test("Clockwise rotation", () => {
+  const component = renderer.create(<Countdown360 seconds={42} clockwise />);
+  const instance = component.getInstance();
+  expect(instance.interval).not.toBeNull();
+});
 
-test('Initialization with autoStart', () => {
+test("Initialization with autoStart", () => {
   [true, false].forEach(autoStart => {
     const component = renderer.create(
-      <Countdown360 seconds={42} autoStart={autoStart}/>
-    )
-    const instance = component.getInstance()
-    expect(instance.state.started).toBe(autoStart)
-  })
-})
+      <Countdown360 seconds={42} autoStart={autoStart} />
+    );
+    const instance = component.getInstance();
+    expect(instance.state.started).toBe(autoStart);
+  });
+});
 
-test('Start and stop', () => {
+test("Start and stop", () => {
   const component = renderer.create(
-    <Countdown360 seconds={42} autoStart={false}/>
-  )
-  const instance = component.getInstance()
-  expect(instance.state.started).toBe(false)
+    <Countdown360 seconds={42} autoStart={false} />
+  );
+  const instance = component.getInstance();
+  expect(instance.state.started).toBe(false);
 
-  instance.start()
-  expect(instance.state.started).toBe(true)
+  instance.start();
+  expect(instance.state.started).toBe(true);
 
-  instance.stop()
-  expect(instance.state.started).toBe(false)
-})
+  instance.stop();
+  expect(instance.state.started).toBe(false);
+});
 
-test('Start and stop while already started or stopped', () => {
+test("Start and stop while already started or stopped", () => {
   const component = renderer.create(
-    <Countdown360 seconds={42} autoStart={true}/>
-  )
-  const instance = component.getInstance()
-  expect(instance.state.started).toBe(true)
+    <Countdown360 seconds={42} autoStart={true} />
+  );
+  const instance = component.getInstance();
+  expect(instance.state.started).toBe(true);
 
-  instance.start()
-  expect(instance.state.started).toBe(true)
+  instance.start();
+  expect(instance.state.started).toBe(true);
 
   for (let i = 0; i < 2; i++) {
-    instance.stop()
-    expect(instance.state.started).toBe(false)
+    instance.stop();
+    expect(instance.state.started).toBe(false);
   }
-})
+});
 
-test('Setup or clear interval when starting and stopping', () => {
+test("Setup or clear interval when starting and stopping", () => {
   const component = renderer.create(
-    <Countdown360 seconds={42} autoStart={false}/>
-  )
-  const instance = component.getInstance()
-  expect(instance.interval).toBeNull()
+    <Countdown360 seconds={42} autoStart={false} />
+  );
+  const instance = component.getInstance();
+  expect(instance.interval).toBeNull();
 
-  instance.start()
-  expect(instance.interval).not.toBeNull()
+  instance.start();
+  expect(instance.interval).not.toBeNull();
 
-  instance.stop()
-  expect(instance.interval).toBeNull()
-})
+  instance.stop();
+  expect(instance.interval).toBeNull();
+});
 
-test('Update interval when changing smooth', () => {
+test("Update interval when changing smooth", () => {
   class ChangeSmoothnessWrapper extends React.Component {
-    constructor (props) {
-      super(props)
-      this.state = { smooth: props.smooth }
+    constructor(props) {
+      super(props);
+      this.state = { smooth: props.smooth };
     }
 
-    toggleSmoothness (smooth) {
-      this.setState({ smooth })
+    toggleSmoothness(smooth) {
+      this.setState({ smooth });
     }
 
-    render () {
-      return <Countdown360 seconds={42} smooth={this.state.smooth} ref={c => { this.c = c }}/>
+    render() {
+      return (
+        <Countdown360
+          seconds={42}
+          smooth={this.state.smooth}
+          ref={c => {
+            this.c = c;
+          }}
+        />
+      );
     }
   }
 
-  const component = renderer.create(
-    <ChangeSmoothnessWrapper smooth={false}/>
-  )
-  const wrapper = component.getInstance()
-  const instance = wrapper.c
-  let interval = instance.interval
-  expect(interval).not.toBeNull()
+  const component = renderer.create(<ChangeSmoothnessWrapper smooth={false} />);
+  const wrapper = component.getInstance();
+  const instance = wrapper.c;
+  let interval = instance.interval;
+  expect(interval).not.toBeNull();
 
-  wrapper.toggleSmoothness(true)
-  expect(instance.interval).not.toBeNull()
-  expect(instance.interval).not.toBe(interval)
-  interval = instance.interval
+  wrapper.toggleSmoothness(true);
+  expect(instance.interval).not.toBeNull();
+  expect(instance.interval).not.toBe(interval);
+  interval = instance.interval;
 
-  wrapper.toggleSmoothness(false)
-  expect(instance.interval).not.toBeNull()
-  expect(instance.interval).not.toBe(interval)
-})
+  wrapper.toggleSmoothness(false);
+  expect(instance.interval).not.toBeNull();
+  expect(instance.interval).not.toBe(interval);
+});
 
-test('Extend timer', () => {
+test("Extend timer", () => {
   [10, -10, -100].forEach(value => {
-    const seconds = 42
-    const component = renderer.create(
-      <Countdown360 seconds={seconds}/>
-    )
-    const instance = component.getInstance()
-    instance.extendTimer(value)
-    const expected = Math.max(seconds + value, 0)
-    expect(instance.state.totalSeconds).toBe(expected)
-    expect(instance.state.secondsLeft).toBeLessThanOrEqual(expected * 1000)
-  })
-})
+    const seconds = 42;
+    const component = renderer.create(<Countdown360 seconds={seconds} />);
+    const instance = component.getInstance();
+    instance.extendTimer(value);
+    const expected = Math.max(seconds + value, 0);
+    expect(instance.state.totalSeconds).toBe(expected);
+    expect(instance.state.secondsLeft).toBeLessThanOrEqual(expected * 1000);
+  });
+});
 
-test('Add seconds', () => {
+test("Add seconds", () => {
   [100, 10, -10, -100].forEach(value => {
-    const seconds = 42
-    const secondsLeft = 30000
-    const component = renderer.create(
-      <Countdown360 seconds={seconds}/>
-    )
-    const instance = component.getInstance()
-    instance.state.secondsLeft = secondsLeft
+    const seconds = 42;
+    const secondsLeft = 30000;
+    const component = renderer.create(<Countdown360 seconds={seconds} />);
+    const instance = component.getInstance();
+    instance.state.secondsLeft = secondsLeft;
 
-    instance.addSeconds(value)
-    const expected = Math.max(Math.min(secondsLeft + value * 1000, seconds * 1000), 0)
+    instance.addSeconds(value);
+    const expected = Math.max(
+      Math.min(secondsLeft + value * 1000, seconds * 1000),
+      0
+    );
 
-    expect(instance.state.secondsLeft).toBe(expected)
-  })
-})
+    expect(instance.state.secondsLeft).toBe(expected);
+  });
+});
 
-test('Handle tick and finish', () => {
-  const seconds = 42
-  const callback = jest.fn()
+test("Handle tick and finish", () => {
+  const seconds = 42;
+  const callback = jest.fn();
   const component = renderer.create(
     <Countdown360 seconds={seconds} onComplete={callback} />
-  )
+  );
 
-  const instance = component.getInstance()
-  const secondsToRemove = 10
-  let lastTick = new Date((new Date()) - secondsToRemove * 1000)
-  instance.setState({ lastTick })
+  const instance = component.getInstance();
+  const secondsToRemove = 10;
+  let lastTick = new Date(new Date() - secondsToRemove * 1000);
+  instance.setState({ lastTick });
 
-  instance.handleTick()
-  expect(instance.state.secondsLeft).toBeLessThan(seconds * 1000)
-  expect(instance.state.secondsLeft).toBeGreaterThan(0)
-  expect(callback).not.toHaveBeenCalled()
+  instance.handleTick();
+  expect(instance.state.secondsLeft).toBeLessThan(seconds * 1000);
+  expect(instance.state.secondsLeft).toBeGreaterThan(0);
+  expect(callback).not.toHaveBeenCalled();
 
-  lastTick = new Date((new Date()) - seconds * 1000)
-  instance.setState({ lastTick })
+  lastTick = new Date(new Date() - seconds * 1000);
+  instance.setState({ lastTick });
 
-  instance.handleTick()
-  expect(instance.state.secondsLeft).toBe(0)
-  expect(callback).toHaveBeenCalledTimes(1)
-})
+  instance.handleTick();
+  expect(instance.state.secondsLeft).toBe(0);
+  expect(callback).toHaveBeenCalledTimes(1);
+});
 
-test('Handle tick while stopped', () => {
-  const seconds = 42
+test("Handle tick while stopped", () => {
+  const seconds = 42;
   const component = renderer.create(
-    <Countdown360 seconds={seconds} autoStart={false}/>
-  )
-  const instance = component.getInstance()
+    <Countdown360 seconds={seconds} autoStart={false} />
+  );
+  const instance = component.getInstance();
 
-  instance.handleTick()
-  expect(instance.state.secondsLeft).toBe(seconds * 1000)
-  expect(instance.state.lastTick).toBeNull()
-})
+  instance.handleTick();
+  expect(instance.state.secondsLeft).toBe(seconds * 1000);
+  expect(instance.state.lastTick).toBeNull();
+});
 
-test('Clear interval when unmounting', () => {
+test("Clear interval when unmounting", () => {
+  const component = renderer.create(<Countdown360 seconds={42} />);
+  const instance = component.getInstance();
+  expect(instance.interval).not.toBeNull();
+  component.unmount();
+  expect(instance.interval).toBeNull();
+});
+
+test("Initialization of negative remaining seconds", () => {
+  const seconds = 30;
+  const remainingSeconds = -30;
   const component = renderer.create(
-    <Countdown360 seconds={42}/>
-  )
-  const instance = component.getInstance()
-  expect(instance.interval).not.toBeNull()
-  component.unmount()
-  expect(instance.interval).toBeNull()
-})
+    <Countdown360 seconds={seconds} remainingSeconds={remainingSeconds} />
+  );
+  const instance = component.getInstance();
+  expect(instance.state.totalSeconds).toBe(seconds);
+  expect(instance.state.secondsLeft).toBe(seconds * 1000);
+});
+
+test("No Initialization of remaining seconds", () => {
+  const seconds = 30;
+  const component = renderer.create(<Countdown360 seconds={seconds} />);
+  const instance = component.getInstance();
+  expect(instance.state.totalSeconds).toBe(seconds);
+  expect(instance.state.secondsLeft).toBe(seconds * 1000);
+});
+
+test("Initialization of remaining seconds bigger than seconds", () => {
+  const seconds = 30;
+  const remainingSeconds = 40;
+  const component = renderer.create(
+    <Countdown360 seconds={seconds} remainingSeconds={remainingSeconds} />
+  );
+  const instance = component.getInstance();
+  expect(instance.state.totalSeconds).toBe(seconds);
+  expect(instance.state.secondsLeft).toBe(seconds * 1000);
+});
+
+test("Initialization of remaining seconds", () => {
+  const seconds = 30;
+  const remainingSeconds = 20;
+  const component = renderer.create(
+    <Countdown360 seconds={seconds} remainingSeconds={remainingSeconds} />
+  );
+  const instance = component.getInstance();
+  expect(instance.state.totalSeconds).toBe(seconds);
+  expect(instance.state.secondsLeft).toBe(remainingSeconds * 1000);
+});

--- a/tests/countdown360.test.js
+++ b/tests/countdown360.test.js
@@ -201,18 +201,18 @@ test('Clear interval when unmounting', () => {
   expect(instance.interval).toBeNull()
 })
 
-test('Initialization of negative remaining seconds', () => {
+test('Initialization of negative starting second', () => {
   const seconds = 30
-  const remainingSeconds = -30
+  const startingSecond = -30
   const component = renderer.create(
-    <Countdown360 seconds={seconds} remainingSeconds={remainingSeconds} />
+    <Countdown360 seconds={seconds} startingSecond={startingSecond} />
   )
   const instance = component.getInstance()
   expect(instance.state.totalSeconds).toBe(seconds)
   expect(instance.state.secondsLeft).toBe(seconds * 1000)
 })
 
-test('No Initialization of remaining seconds', () => {
+test('No Initialization of starting second', () => {
   const seconds = 30
   const component = renderer.create(<Countdown360 seconds={seconds} />)
   const instance = component.getInstance()
@@ -220,24 +220,24 @@ test('No Initialization of remaining seconds', () => {
   expect(instance.state.secondsLeft).toBe(seconds * 1000)
 })
 
-test('Initialization of remaining seconds bigger than seconds', () => {
+test('Initialization of starting second bigger than seconds', () => {
   const seconds = 30
-  const remainingSeconds = 40
+  const startingSecond = 40
   const component = renderer.create(
-    <Countdown360 seconds={seconds} remainingSeconds={remainingSeconds} />
+    <Countdown360 seconds={seconds} startingSecond={startingSecond} />
   )
   const instance = component.getInstance()
   expect(instance.state.totalSeconds).toBe(seconds)
   expect(instance.state.secondsLeft).toBe(seconds * 1000)
 })
 
-test('Initialization of remaining seconds', () => {
+test('Initialization of starting second', () => {
   const seconds = 30
-  const remainingSeconds = 20
+  const startingSecond = 20
   const component = renderer.create(
-    <Countdown360 seconds={seconds} remainingSeconds={remainingSeconds} />
+    <Countdown360 seconds={seconds} startingSecond={startingSecond} />
   )
   const instance = component.getInstance()
   expect(instance.state.totalSeconds).toBe(seconds)
-  expect(instance.state.secondsLeft).toBe(remainingSeconds * 1000)
+  expect(instance.state.secondsLeft).toBe(startingSecond * 1000)
 })


### PR DESCRIPTION
Added remainingSeconds prop to let the timer start from a position to view the remaining time from the total time

Example  showing remaining 15 minutes from a total of 60 minutes (ignoring styling props)
```
 <Countdown360
    seconds={60 * 60}
    remainingSeconds={15 * 60}
  />
```
![countdown](https://user-images.githubusercontent.com/35541698/71589105-5dc57b00-2b2c-11ea-9a61-c31a1f4c9541.JPG)


Some use cases:
- Indicating time remaining in examinations..etc
- Indicating time remaining in  sport games ..etc
- Generally indicating how much time is left from a total time